### PR TITLE
Enable native Zeebe client's support of job streaming

### DIFF
--- a/engine-adapter/c8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingServiceTaskDelivery.kt
+++ b/engine-adapter/c8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingServiceTaskDelivery.kt
@@ -35,7 +35,6 @@ class SubscribingServiceTaskDelivery(
             .jobType(activeSubscription.taskDescriptionKey)
             .handler { _, job -> consumeActivatedJob(activeSubscription, job, zeebeClient) }
             .name(workerId)
-            .streamEnabled(false)
             .forSubscription(activeSubscription)
             // FIXME -> metrics to setup
             .open()

--- a/engine-adapter/c8-spring-boot-starter/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/C8ZeebeClientConfigurationTest.kt
+++ b/engine-adapter/c8-spring-boot-starter/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/C8ZeebeClientConfigurationTest.kt
@@ -1,0 +1,78 @@
+package dev.bpmcrafters.processengineapi.adapter.c8
+
+import dev.bpmcrafters.processengineapi.impl.task.SubscriptionRepository
+import dev.bpmcrafters.processengineapi.impl.task.TaskSubscriptionHandle
+import io.camunda.zeebe.gateway.protocol.GatewayGrpc
+import io.grpc.ClientInterceptor
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+
+/**
+ * This test demonstrates that when camunda.client.defaults.stream-enabled=true is configured,
+ * the job workers created by the adapter should respect this configuration.
+ */
+@SpringBootTest
+@Import(C8ZeebeClientConfigurationTest.TestConfiguration::class)
+@ActiveProfiles("itest")
+@TestPropertySource(
+  properties = [
+    "camunda.client.zeebe.defaults.stream-enabled=true"
+  ]
+)
+class C8ZeebeClientConfigurationTest {
+
+  class TestConfiguration {
+
+    /* Initialize subscriptions and prepare a list to capture commands sent to the server */
+    @Bean("commandsList")
+    fun initSubscriptionsAndPrepareCommandList(subscriptionRepository: SubscriptionRepository): ArrayList<String> {
+      subscriptionsInitHook(subscriptionRepository)
+      return java.util.ArrayList()
+    }
+
+    /* A gRPC interceptor that captures the commands sent to the server */
+    @Bean("diagnostic-interceptor")
+    fun diagnosticGrpcInterceptor(commandsCaptor: ArrayList<String>): ClientInterceptor = object : ClientInterceptor {
+      override fun <ReqT, RespT> interceptCall(
+        method: io.grpc.MethodDescriptor<ReqT, RespT>,
+        callOptions: io.grpc.CallOptions,
+        next: io.grpc.Channel
+      ): io.grpc.ClientCall<ReqT, RespT> {
+        commandsCaptor.add(method.fullMethodName!!)
+        return next.newCall(method, callOptions)
+      }
+    }
+
+    private fun subscriptionsInitHook(subscriptionRepository: SubscriptionRepository) {
+      subscriptionRepository.createTaskSubscription(
+        TaskSubscriptionHandle(
+          taskType = dev.bpmcrafters.processengineapi.task.TaskType.EXTERNAL,
+          taskDescriptionKey = "test-external-task",
+          action = { _, _ -> },
+          restrictions = mapOf(),
+          payloadDescription = null,
+          termination = { _ -> }
+        ))
+    }
+  }
+
+  @Autowired
+  @Qualifier("commandsList")
+  private lateinit var commandsSentToServer: ArrayList<String>
+
+  @Test
+  fun `autoconfigured job workers should obey Zeebe client's configuration and use job streaming if enabled`() {
+    // Given the configuration camunda.client.defaults.stream-enabled=true
+    // And a subscription for an external task exists
+    // Then autoconfiguration would create and start job workers with job streaming request sent to the server
+    assertThat(commandsSentToServer.contains(GatewayGrpc.getStreamActivatedJobsMethod().fullMethodName)).isTrue()
+
+  }
+}


### PR DESCRIPTION
Removal of the hardcoded 'false' of the job streaming enables job streaming if configured in Zeebe client's configuration.