### PR TITLE
fix(c8): tasks not delivered when lockDuratio is set

### DIFF
--- a/engine-adapter/c8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/ActivatedJobMatcher.kt
+++ b/engine-adapter/c8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/ActivatedJobMatcher.kt
@@ -1,0 +1,43 @@
+package dev.bpmcrafters.processengineapi.adapter.c8.task.delivery
+
+import dev.bpmcrafters.processengineapi.CommonRestrictions
+import dev.bpmcrafters.processengineapi.impl.task.TaskSubscriptionHandle
+import dev.bpmcrafters.processengineapi.task.TaskType
+import io.camunda.client.api.response.ActivatedJob
+
+/**
+ * Determines whether a [TaskSubscriptionHandle] should receive a given [ActivatedJob]
+ * by checking task type, job type, and all restriction entries.
+ *
+ * Note: when adding a new restriction key, add a corresponding when-case in
+ * [jobMatchesRestriction]; unhandled keys fall through to `else -> false`
+ * and silently prevent task delivery.
+ */
+class ActivatedJobMatcher {
+
+  private val keysToIgnore = setOf(
+    "workerLockDurationInMilliseconds",
+  )
+
+  fun matches(subscription: TaskSubscriptionHandle, job: ActivatedJob): Boolean {
+    return subscription.taskType == TaskType.EXTERNAL
+      && (subscription.taskDescriptionKey == null || subscription.taskDescriptionKey == job.type)
+      && subscription.restrictions.all { jobMatchesRestriction(job, it) }
+  }
+
+  private fun jobMatchesRestriction(
+    job: ActivatedJob,
+    restriction: Map.Entry<String, String>,
+  ): Boolean {
+    val (key, value) = restriction
+    if (keysToIgnore.contains(key)) return true
+    return when (key) {
+      CommonRestrictions.EXECUTION_ID -> value == "${job.elementInstanceKey}"
+      CommonRestrictions.ACTIVITY_ID -> value == job.elementId
+      CommonRestrictions.TENANT_ID -> value == job.tenantId
+      CommonRestrictions.PROCESS_INSTANCE_ID -> value == "${job.processInstanceKey}"
+      CommonRestrictions.PROCESS_DEFINITION_ID -> value == "${job.processDefinitionKey}"
+      else -> false
+    }
+  }
+}

--- a/engine-adapter/c8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingServiceTaskDelivery.kt
+++ b/engine-adapter/c8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingServiceTaskDelivery.kt
@@ -22,7 +22,8 @@ class SubscribingServiceTaskDelivery(
   private val subscriptionRepository: SubscriptionRepository,
   private val workerId: String,
   private val retryTimeoutInSeconds: Long,
-  private val lockDurationInSeconds: Long
+  private val lockDurationInSeconds: Long,
+  private val jobMatcher: ActivatedJobMatcher = ActivatedJobMatcher()
 ) {
 
   fun subscribe() {
@@ -48,7 +49,7 @@ class SubscribingServiceTaskDelivery(
   }
 
   private fun consumeActivatedJob(activeSubscription: TaskSubscriptionHandle, job: ActivatedJob, camundaClient: CamundaClient) {
-    if (activeSubscription.matches(job)) {
+    if (jobMatcher.matches(activeSubscription, job)) {
       subscriptionRepository.activateSubscriptionForTask("${job.key}", activeSubscription)
       val variables = job.variablesAsMap.filterBySubscription(activeSubscription)
       try {
@@ -71,30 +72,6 @@ class SubscribingServiceTaskDelivery(
       logger.trace { "PROCESS-ENGINE-C8-045: Successfully returned service task ${job.key} not matching subscriptions." }
     }
 
-  }
-
-  /*
-   * Additional restrictions to check.
-   * The activated job can be completed by the Subscription strategy and is correct type (topic).
-   */
-  internal fun TaskSubscriptionHandle.matches(job: ActivatedJob): Boolean {
-    return this.taskType == TaskType.EXTERNAL
-      && (this.taskDescriptionKey == null || this.taskDescriptionKey == job.type)
-      && this.restrictions
-      .minus( // ignore some restrictions that are not relevant for external tasks or handled differntly
-        "workerLockDurationInMilliseconds"
-      )
-      .all {
-      when (it.key) {
-        CommonRestrictions.EXECUTION_ID -> it.value == "${job.elementInstanceKey}"
-        CommonRestrictions.ACTIVITY_ID -> it.value == job.elementId
-        CommonRestrictions.TENANT_ID -> it.value == job.tenantId
-        CommonRestrictions.PROCESS_INSTANCE_ID -> it.value == "${job.processInstanceKey}"
-        CommonRestrictions.PROCESS_DEFINITION_ID -> it.value == "${job.processDefinitionKey}"
-        else -> false
-      }
-    }
-    // job.customHeaders // FIXME: analyze this! user/service task, etc..
   }
 
   private fun JobWorkerBuilderStep3.forSubscription(subscription: TaskSubscriptionHandle): JobWorkerBuilderStep3 {

--- a/engine-adapter/c8-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/ActivatedJobMatcherTest.kt
+++ b/engine-adapter/c8-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/ActivatedJobMatcherTest.kt
@@ -1,0 +1,187 @@
+package dev.bpmcrafters.processengineapi.adapter.c8.task.delivery
+
+import dev.bpmcrafters.processengineapi.CommonRestrictions
+import dev.bpmcrafters.processengineapi.impl.task.TaskSubscriptionHandle
+import dev.bpmcrafters.processengineapi.task.TaskType
+import io.camunda.client.api.response.ActivatedJob
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class ActivatedJobMatcherTest {
+
+  private val matcher = ActivatedJobMatcher()
+
+  @Test
+  fun `matches should return true when all real restrictions are satisfied`() {
+    val job: ActivatedJob = mock()
+    whenever(job.type).thenReturn("my-topic")
+    whenever(job.processDefinitionKey).thenReturn(123L)
+
+    val subscription = TaskSubscriptionHandle(
+      taskType = TaskType.EXTERNAL,
+      taskDescriptionKey = "my-topic",
+      payloadDescription = null,
+      restrictions = mapOf(
+        CommonRestrictions.PROCESS_DEFINITION_ID to "123",
+      ),
+      action = { _, _ -> },
+      termination = {}
+    )
+
+    assertThat(matcher.matches(subscription, job)).isTrue()
+  }
+
+  @Test
+  fun `matches should return true when workerLockDurationInMilliseconds is in restrictions`() {
+    val job: ActivatedJob = mock()
+    whenever(job.type).thenReturn("my-topic")
+    whenever(job.processDefinitionKey).thenReturn(123L)
+
+    val subscription = TaskSubscriptionHandle(
+      taskType = TaskType.EXTERNAL,
+      taskDescriptionKey = "my-topic",
+      payloadDescription = null,
+      restrictions = mapOf(
+        CommonRestrictions.PROCESS_DEFINITION_ID to "123",
+        "workerLockDurationInMilliseconds" to "25000",
+      ),
+      action = { _, _ -> },
+      termination = {}
+    )
+
+    assertThat(matcher.matches(subscription, job)).isTrue()
+  }
+
+  @Test
+  fun `matches should return false when a real restriction value doesn't match`() {
+    val job: ActivatedJob = mock()
+    whenever(job.type).thenReturn("my-topic")
+    whenever(job.processDefinitionKey).thenReturn(456L)
+
+    val subscription = TaskSubscriptionHandle(
+      taskType = TaskType.EXTERNAL,
+      taskDescriptionKey = "my-topic",
+      payloadDescription = null,
+      restrictions = mapOf(
+        CommonRestrictions.PROCESS_DEFINITION_ID to "123",
+      ),
+      action = { _, _ -> },
+      termination = {}
+    )
+
+    assertThat(matcher.matches(subscription, job)).isFalse()
+  }
+
+  @Test
+  fun `matches should return false when taskType is not EXTERNAL`() {
+    val job: ActivatedJob = mock()
+    whenever(job.type).thenReturn("my-topic")
+
+    val subscription = TaskSubscriptionHandle(
+      taskType = TaskType.USER,
+      taskDescriptionKey = "my-topic",
+      payloadDescription = null,
+      restrictions = mapOf(),
+      action = { _, _ -> },
+      termination = {}
+    )
+
+    assertThat(matcher.matches(subscription, job)).isFalse()
+  }
+
+  @Test
+  fun `matches should return false when job type doesn't match taskDescriptionKey`() {
+    val job: ActivatedJob = mock()
+    whenever(job.type).thenReturn("other-topic")
+    whenever(job.processDefinitionKey).thenReturn(123L)
+
+    val subscription = TaskSubscriptionHandle(
+      taskType = TaskType.EXTERNAL,
+      taskDescriptionKey = "my-topic",
+      payloadDescription = null,
+      restrictions = mapOf(),
+      action = { _, _ -> },
+      termination = {}
+    )
+
+    assertThat(matcher.matches(subscription, job)).isFalse()
+  }
+
+  @Test
+  fun `matches should return true when taskDescriptionKey is null`() {
+    val job: ActivatedJob = mock()
+    whenever(job.type).thenReturn("any-topic")
+    whenever(job.processDefinitionKey).thenReturn(123L)
+
+    val subscription = TaskSubscriptionHandle(
+      taskType = TaskType.EXTERNAL,
+      taskDescriptionKey = null,
+      payloadDescription = null,
+      restrictions = mapOf(
+        CommonRestrictions.PROCESS_DEFINITION_ID to "123",
+      ),
+      action = { _, _ -> },
+      termination = {}
+    )
+
+    assertThat(matcher.matches(subscription, job)).isTrue()
+  }
+
+  @Test
+  fun `matches should check all restriction types`() {
+    val job: ActivatedJob = mock()
+    whenever(job.type).thenReturn("my-topic")
+    whenever(job.elementInstanceKey).thenReturn(100L)
+    whenever(job.elementId).thenReturn("activity1")
+    whenever(job.tenantId).thenReturn("tenant1")
+    whenever(job.processInstanceKey).thenReturn(200L)
+    whenever(job.processDefinitionKey).thenReturn(123L)
+
+    val subscription = TaskSubscriptionHandle(
+      taskType = TaskType.EXTERNAL,
+      taskDescriptionKey = "my-topic",
+      payloadDescription = null,
+      restrictions = mapOf(
+        CommonRestrictions.EXECUTION_ID to "100",
+        CommonRestrictions.ACTIVITY_ID to "activity1",
+        CommonRestrictions.TENANT_ID to "tenant1",
+        CommonRestrictions.PROCESS_INSTANCE_ID to "200",
+        CommonRestrictions.PROCESS_DEFINITION_ID to "123",
+      ),
+      action = { _, _ -> },
+      termination = {}
+    )
+
+    assertThat(matcher.matches(subscription, job)).isTrue()
+  }
+
+  @Test
+  fun `matches should return false if any single restriction doesn't match when multiple are specified`() {
+    val job: ActivatedJob = mock()
+    whenever(job.type).thenReturn("my-topic")
+    whenever(job.elementInstanceKey).thenReturn(100L)
+    whenever(job.elementId).thenReturn("activity1")
+    whenever(job.tenantId).thenReturn("tenant1")
+    whenever(job.processInstanceKey).thenReturn(200L)
+    whenever(job.processDefinitionKey).thenReturn(999L) // mismatch
+
+    val subscription = TaskSubscriptionHandle(
+      taskType = TaskType.EXTERNAL,
+      taskDescriptionKey = "my-topic",
+      payloadDescription = null,
+      restrictions = mapOf(
+        CommonRestrictions.EXECUTION_ID to "100",
+        CommonRestrictions.ACTIVITY_ID to "activity1",
+        CommonRestrictions.TENANT_ID to "tenant1",
+        CommonRestrictions.PROCESS_INSTANCE_ID to "200",
+        CommonRestrictions.PROCESS_DEFINITION_ID to "123",
+      ),
+      action = { _, _ -> },
+      termination = {}
+    )
+
+    assertThat(matcher.matches(subscription, job)).isFalse()
+  }
+}

--- a/engine-adapter/c8-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingServiceTaskDeliveryTest.kt
+++ b/engine-adapter/c8-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingServiceTaskDeliveryTest.kt
@@ -11,15 +11,7 @@ import org.mockito.kotlin.whenever
 
 class SubscribingServiceTaskDeliveryTest {
 
-  // We need an instance of SubscribingServiceTaskDelivery because matches is an extension function
-  // on TaskSubscriptionHandle declared inside SubscribingServiceTaskDelivery class.
-  private val delivery = SubscribingServiceTaskDelivery(
-    camundaClient = mock(),
-    subscriptionRepository = mock(),
-    workerId = "test-worker",
-    retryTimeoutInSeconds = 10,
-    lockDurationInSeconds = 60
-  )
+  private val matcher = ActivatedJobMatcher()
 
   @Test
   fun `should match when all restrictions match`() {
@@ -41,9 +33,7 @@ class SubscribingServiceTaskDeliveryTest {
       whenever(it.tenantId).thenReturn("tenant-1")
     }
 
-    with(delivery) {
-      assertThat(subscription.matches(job)).isTrue()
-    }
+    assertThat(matcher.matches(subscription, job)).isTrue()
   }
 
   @Test
@@ -65,11 +55,9 @@ class SubscribingServiceTaskDeliveryTest {
       whenever(it.elementId).thenReturn("activity-1")
     }
 
-    with(delivery) {
-      // It should match even if workerLockDurationInMilliseconds is present in restrictions
-      // but not present in ActivatedJob (it's not even a field in ActivatedJob that we check)
-      assertThat(subscription.matches(job)).isTrue()
-    }
+    // It should match even if workerLockDurationInMilliseconds is present in restrictions
+    // but not present in ActivatedJob (it's not even a field in ActivatedJob that we check)
+    assertThat(matcher.matches(subscription, job)).isTrue()
   }
 
   @Test
@@ -87,9 +75,7 @@ class SubscribingServiceTaskDeliveryTest {
       whenever(it.type).thenReturn("test-topic")
     }
 
-    with(delivery) {
-      assertThat(subscription.matches(job)).isFalse()
-    }
+    assertThat(matcher.matches(subscription, job)).isFalse()
   }
 
   @Test
@@ -107,9 +93,7 @@ class SubscribingServiceTaskDeliveryTest {
       whenever(it.type).thenReturn("other-topic")
     }
 
-    with(delivery) {
-      assertThat(subscription.matches(job)).isFalse()
-    }
+    assertThat(matcher.matches(subscription, job)).isFalse()
   }
 
   @Test
@@ -130,9 +114,7 @@ class SubscribingServiceTaskDeliveryTest {
       whenever(it.elementId).thenReturn("activity-2")
     }
 
-    with(delivery) {
-      assertThat(subscription.matches(job)).isFalse()
-    }
+    assertThat(matcher.matches(subscription, job)).isFalse()
   }
 
   @Test
@@ -150,8 +132,6 @@ class SubscribingServiceTaskDeliveryTest {
       whenever(it.type).thenReturn("any-topic")
     }
 
-    with(delivery) {
-      assertThat(subscription.matches(job)).isTrue()
-    }
+    assertThat(matcher.matches(subscription, job)).isTrue()
   }
 }


### PR DESCRIPTION
Matching pattern follows the equivalent fix in process-engine-adapters-cib-seven PR #42.

Closes #198

(saw that you've aleady closed it @zambrovski - however could think about this as a kind of refacotring - since it would outsource the logic for jobMatching to a single-file, that better testable).

Feel free to comment, or reject if you dont like that :D