### PR TITLE
refactor: use CommonRestrictions constants instead of raw restriction-key strings

### DIFF
--- a/engine-adapter/c8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/process/StartProcessApiImpl.kt
+++ b/engine-adapter/c8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/process/StartProcessApiImpl.kt
@@ -100,7 +100,7 @@ class StartProcessApiImpl(
   private fun ProcessInstanceEvent.toProcessInformation() = ProcessInformation(
     instanceId = "${this.processInstanceKey}",
     meta = mapOf(
-      "processDefinitionId" to "${this.processDefinitionKey}",
+      CommonRestrictions.PROCESS_DEFINITION_ID to "${this.processDefinitionKey}",
       CommonRestrictions.PROCESS_DEFINITION_KEY to this.bpmnProcessId,
       CommonRestrictions.TENANT_ID to this.tenantId,
     )

--- a/engine-adapter/c8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/PullUserTaskDelivery.kt
+++ b/engine-adapter/c8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/PullUserTaskDelivery.kt
@@ -99,7 +99,7 @@ class PullUserTaskDelivery(
       && (this.taskDescriptionKey == null || this.taskDescriptionKey == task.elementId)
       && this.restrictions
       .minus( // ignore some restrictions that are not relevant for external tasks or handled differntly
-        "workerLockDurationInMilliseconds"
+        CommonRestrictions.WORKER_LOCK_DURATION_IN_MILLISECONDS
       )
       .all {
         when (it.key) {

--- a/engine-adapter/c8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingRefreshingUserTaskDelivery.kt
+++ b/engine-adapter/c8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingRefreshingUserTaskDelivery.kt
@@ -137,7 +137,7 @@ class SubscribingRefreshingUserTaskDelivery(
       && (this.taskDescriptionKey == null || this.taskDescriptionKey == job.elementId)
       && this.restrictions
       .minus( // ignore some restrictions that are not relevant for external tasks or handled differntly
-        "workerLockDurationInMilliseconds"
+        CommonRestrictions.WORKER_LOCK_DURATION_IN_MILLISECONDS
       )
       .all {
       when (it.key) {

--- a/engine-adapter/c8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingServiceTaskDelivery.kt
+++ b/engine-adapter/c8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingServiceTaskDelivery.kt
@@ -82,7 +82,7 @@ class SubscribingServiceTaskDelivery(
       && (this.taskDescriptionKey == null || this.taskDescriptionKey == job.type)
       && this.restrictions
       .minus( // ignore some restrictions that are not relevant for external tasks or handled differntly
-        "workerLockDurationInMilliseconds"
+        CommonRestrictions.WORKER_LOCK_DURATION_IN_MILLISECONDS
       )
       .all {
       when (it.key) {
@@ -113,7 +113,7 @@ class SubscribingServiceTaskDelivery(
   }
 
   private fun getLockDuration(subscription: TaskSubscriptionHandle): Long {
-    val customLockDuration = subscription.restrictions["workerLockDurationInMilliseconds"]
+    val customLockDuration = subscription.restrictions[CommonRestrictions.WORKER_LOCK_DURATION_IN_MILLISECONDS]
     return customLockDuration?.toLong() ?: (lockDurationInSeconds * 1000)
   }
 }

--- a/engine-adapter/c8-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/decision/EvaluateDecisionApiImplTest.kt
+++ b/engine-adapter/c8-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/decision/EvaluateDecisionApiImplTest.kt
@@ -1,5 +1,6 @@
 package dev.bpmcrafters.processengineapi.adapter.c8.decision
 
+import dev.bpmcrafters.processengineapi.CommonRestrictions
 import dev.bpmcrafters.processengineapi.decision.DecisionByRefEvaluationCommand
 import io.camunda.client.CamundaClient
 import io.camunda.client.api.CamundaFuture
@@ -48,7 +49,7 @@ class EvaluateDecisionApiImplTest {
     assertEquals("Collect MOutput Decision", meta["decisionDefinitionName"])
     assertEquals("MainDecision", meta["decisionRequirementsId"])
     assertEquals("2251799813703258", meta["decisionRequirementsKey"])
-    assertEquals("<default>", meta["tenantId"]) // CommonRestrictions.TENANT_ID
+    assertEquals("<default>", meta[CommonRestrictions.TENANT_ID])
     assertEquals("", meta["failedDecisionId"])
     assertEquals("", meta["failureMessage"])
   }

--- a/engine-adapter/c8-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingRefreshingUserTaskDeliveryTest.kt
+++ b/engine-adapter/c8-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingRefreshingUserTaskDeliveryTest.kt
@@ -64,7 +64,7 @@ class SubscribingRefreshingUserTaskDeliveryTest {
       taskDescriptionKey = "user-task-1",
       restrictions = mapOf(
         CommonRestrictions.ACTIVITY_ID to "user-task-1",
-        "workerLockDurationInMilliseconds" to "5000"
+        CommonRestrictions.WORKER_LOCK_DURATION_IN_MILLISECONDS to "5000"
       ),
       payloadDescription = null,
       action = { _, _ -> },

--- a/engine-adapter/c8-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingServiceTaskDeliveryTest.kt
+++ b/engine-adapter/c8-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingServiceTaskDeliveryTest.kt
@@ -53,7 +53,7 @@ class SubscribingServiceTaskDeliveryTest {
       taskDescriptionKey = "test-topic",
       restrictions = mapOf(
         CommonRestrictions.ACTIVITY_ID to "activity-1",
-        "workerLockDurationInMilliseconds" to "5000"
+        CommonRestrictions.WORKER_LOCK_DURATION_IN_MILLISECONDS to "5000"
       ),
       payloadDescription = null,
       action = { _, _ -> },


### PR DESCRIPTION
## Summary

Replaces hardcoded restriction-key string literals with the constants from `dev.bpmcrafters.processengineapi.CommonRestrictions`, introduced in process-engine-api 1.6 (commit bb1a250). The repo already depends on 1.6 (`pom.xml`), and the constant `WORKER_LOCK_DURATION_IN_MILLISECONDS = "workerLockDurationInMilliseconds"` was verified to exist in the resolved artifact.

## Changes (8 sites, 6 files)

`workerLockDurationInMilliseconds` → `CommonRestrictions.WORKER_LOCK_DURATION_IN_MILLISECONDS`:
- `PullUserTaskDelivery.kt`
- `SubscribingRefreshingUserTaskDelivery.kt`
- `SubscribingServiceTaskDelivery.kt` (2 occurrences)
- `SubscribingServiceTaskDeliveryTest.kt`
- `SubscribingRefreshingUserTaskDeliveryTest.kt`

Same class of issue — other raw restriction keys that already have a constant:
- `StartProcessApiImpl.kt`: `"processDefinitionId"` → `CommonRestrictions.PROCESS_DEFINITION_ID` (sat right next to existing `CommonRestrictions.*` entries)
- `EvaluateDecisionApiImplTest.kt`: `meta["tenantId"]` → `meta[CommonRestrictions.TENANT_ID]` (added the import; removed the now-redundant `// CommonRestrictions.TENANT_ID` comment)

## Verification

- `./mvnw -pl engine-adapter/c8-core -am test-compile` → **BUILD SUCCESS**
- No raw restriction-key literals remain (grep verified)