### PR TITLE
chore(ci): pin github actions to exact version tags

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -34,14 +34,14 @@ jobs:
     steps:
       # Checkout the code
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.0
 
       - name: Expose branch name
         run: echo ${{ github.ref }}
 
       # Setup JDK and Maven
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.3.0
         with:
           java-version: 17
           distribution: 'zulu'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,11 +14,11 @@ jobs:
     name: Build and run tests
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.0
 
       # Setup JDK and .m2/settings.xml
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.3.0
         with:
           java-version-file: .java-version
           distribution: 'zulu'

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@master
+      uses: actions/checkout@v7.0.0
     - name: Create Release Notes Markdown
       uses: docker://ghcr.io/rohwerj/release-notes-generator-action:v1.0.0
       env:
@@ -27,7 +27,7 @@ jobs:
         echo "VERSION=$VERSION" >> $GITHUB_ENV
     - name: Create a Draft Release Notes on GitHub
       id: create_release
-      uses: actions/create-release@v1
+      uses: actions/create-release@v1.1.4
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
       with:


### PR DESCRIPTION
## What
Pin all external GitHub Actions to **exact version tags** (`@vX.Y.Z`) instead of moving references (major-only `@vX`, or branch refs like `@master`).

## Why
Moving refs silently pull in new code on every run. A major-only tag (`@v6`) follows the whole major line; a branch ref (`@master`) follows whatever lands on that branch — both can break CI without any change on our side. Exact tags make the CI inputs reproducible and reviewable.

## Mapping (before → after)

| Action | File(s) | before | after |
|---|---|---|---|
| `actions/checkout` | development.yml, master.yml | `@v6` | `@v7.0.0` |
| `actions/checkout` | release-notes.yml | `@master` ⚠️ branch ref | `@v7.0.0` |
| `actions/setup-java` | development.yml, master.yml | `@v5` | `@v5.3.0` |
| `actions/create-release` | release-notes.yml | `@v1` | `@v1.1.4` |

⚠️ **`actions/checkout@master` was a branch ref** in `release-notes.yml` — the most volatile kind of moving reference. It is now pinned like the others.

> Note: `actions/checkout` was bumped across a major (v6 → v7.0.0) at request, since all refs were pinned to the latest full version.

Left untouched (already exact / not a moving GitHub-action ref):
- `codecov/codecov-action@v7.0.0` — already full semver
- `docker://ghcr.io/rohwerj/release-notes-generator-action:v1.0.0` — docker image, already pinned

## Verification
- Grep confirms no moving refs remain in `.github/workflows/`.
- `actionlint` parses all workflows; the only findings are pre-existing shellcheck/expression warnings inside `run:` blocks (identical count on the base branch — not introduced here).

## Next step (out of scope)
Tag pinning protects against major drift but tags can still be re-pointed. **Full-SHA pinning** (`@<40-char-sha>`) would be the next hardening step for fully immutable CI inputs.