### PR TITLE
Fix task sync errors on errors

### DIFF
--- a/engine-adapter/c8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/PullUserTaskDelivery.kt
+++ b/engine-adapter/c8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/PullUserTaskDelivery.kt
@@ -1,6 +1,5 @@
 package dev.bpmcrafters.processengineapi.adapter.c8.task.delivery
 
-import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import dev.bpmcrafters.processengineapi.CommonRestrictions
 import dev.bpmcrafters.processengineapi.adapter.c8.task.asJson
@@ -23,7 +22,9 @@ class PullUserTaskDelivery(
   private val subscriptionRepository: SubscriptionRepository
 ) : RefreshableDelivery {
 
-  override fun refresh() {
+  private val refreshMonitor = Any()
+
+  override fun refresh() = synchronized(refreshMonitor) {
     val subscriptions = subscriptionRepository.getTaskSubscriptions().filter { s -> s.taskType == TaskType.USER }
     // FIXME -> reverse lookup for all active subscriptions
     // if the task is not retrieved but active subscription has a task, call modification#terminated hook
@@ -42,55 +43,64 @@ class PullUserTaskDelivery(
             ?.let { activeSubscription ->
 
               val taskId = task.userTaskKey.toString()
-              subscriptionRepository.activateSubscriptionForTask(taskId, activeSubscription)
-
-              val form = task.formKey?.let { camundaClient.newUserTaskGetFormRequest(task.userTaskKey).send().join() }
-              val taskInformation = task.toTaskInformation(form).withReason(
-                if (deliveredTaskIds.contains(taskId) && subscriptionRepository.getActiveSubscriptionForTask(taskId) == activeSubscription) {
-                  // task was already delivered to this subscription
-                  TaskInformation.UPDATE
-                } else {
-                  // task is new for this subscription
-                  TaskInformation.CREATE
-                }
-              )
-              // remove from already delivered
-              deliveredTaskIds.remove(taskId)
-
-              val variableRequest = camundaClient.newUserTaskVariableSearchRequest(task.userTaskKey).apply {
-                if (!activeSubscription.payloadDescription.isNullOrEmpty()) {
-                  this.filter { it.name { variable -> variable.`in`(activeSubscription.payloadDescription!!.toList()) } }
-                }
-              }
-
-              val result = variableRequest.withFullValues().send().join().items()
-
-              val variablesFromTask = result.associate { variable ->
-                variable.name to variable.value
-              }.asJson().parseJson(jacksonObjectMapper())
-
-              val variables = variablesFromTask.filterBySubscription(activeSubscription)
-
+              val wasDeliveredToSubscription =
+                deliveredTaskIds.contains(taskId) &&
+                  subscriptionRepository.getActiveSubscriptionForTask(taskId) == activeSubscription
               try {
+                val form = task.formKey?.let { camundaClient.newUserTaskGetFormRequest(task.userTaskKey).send().join() }
+                val taskInformation = task.toTaskInformation(form).withReason(
+                  if (wasDeliveredToSubscription) {
+                    TaskInformation.UPDATE
+                  } else {
+                    TaskInformation.CREATE
+                  }
+                )
+
+                val variableRequest = camundaClient.newUserTaskVariableSearchRequest(task.userTaskKey).apply {
+                  if (!activeSubscription.payloadDescription.isNullOrEmpty()) {
+                    this.filter { it.name { variable -> variable.`in`(activeSubscription.payloadDescription!!.toList()) } }
+                  }
+                }
+
+                val result = variableRequest.withFullValues().send().join().items()
+
+                val variablesFromTask = result.associate { variable ->
+                  variable.name to variable.value
+                }.asJson().parseJson(jacksonObjectMapper())
+
+                val variables = variablesFromTask.filterBySubscription(activeSubscription)
+
+                subscriptionRepository.activateSubscriptionForTask(taskId, activeSubscription)
                 logger.debug { "PROCESS-ENGINE-C8-031: delivering user task ${taskId}." }
                 activeSubscription.action.accept(taskInformation, variables)
                 logger.debug { "PROCESS-ENGINE-C8-032: successfully delivered user task ${taskId}." }
               } catch (e: Exception) {
-                logger.error { "PROCESS-ENGINE-C8-031: error delivering user task ${taskId}: ${e.message}" }
-                subscriptionRepository.deactivateSubscriptionForTask(taskId = taskId)
+                logger.error(e) { "PROCESS-ENGINE-C8-031: error delivering user task ${taskId}: ${e.message}" }
+                deactivateAndTerminate(taskId)
+              } finally {
+                deliveredTaskIds.remove(taskId)
               }
             }
         }
       deliveredTaskIds.forEach { taskId ->
-        subscriptionRepository.getActiveSubscriptionForTask(taskId)?.let {
+        if (subscriptionRepository.getActiveSubscriptionForTask(taskId) != null) {
           logger.trace { "PROCESS-ENGINE-C8-033: User task is gone, sending termination to the handler." }
-          it.termination.accept(TaskInformation(taskId, mapOf()).withReason(TaskInformation.DELETE))
-          subscriptionRepository.deactivateSubscriptionForTask(taskId)
+          deactivateAndTerminate(taskId)
           logger.trace { "PROCESS-ENGINE-C8-034: Termination sent to handler and user task is removed." }
         }
       }
     } else {
       logger.trace { "PROCESS-ENGINE-C8-035: pulling user tasks disabled, no subscriptions." }
+    }
+  }
+
+  private fun deactivateAndTerminate(taskId: String) {
+    subscriptionRepository.deactivateSubscriptionForTask(taskId)?.let {
+      try {
+        it.termination.accept(TaskInformation(taskId, mapOf()).withReason(TaskInformation.DELETE))
+      } catch (terminationError: Exception) {
+        logger.error(terminationError) { "PROCESS-ENGINE-C8-036: failed to terminate user task ${taskId} during cleanup." }
+      }
     }
   }
 

--- a/engine-adapter/c8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingRefreshingZeebeJobUserTaskDelivery.kt
+++ b/engine-adapter/c8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingRefreshingZeebeJobUserTaskDelivery.kt
@@ -29,6 +29,7 @@ class SubscribingRefreshingZeebeJobUserTaskDelivery(
 ) : SubscribingUserTaskDelivery, RefreshableDelivery {
 
   private var jobWorkerRegistry: Map<TaskSubscription, JobWorker> = emptyMap()
+  private val refreshMonitor = Any()
 
   fun subscribe() {
     val subscriptions = subscriptionRepository.getTaskSubscriptions().filter { s -> s.taskType == TaskType.USER }
@@ -59,20 +60,24 @@ class SubscribingRefreshingZeebeJobUserTaskDelivery(
 
   private fun consumeActivatedJob(activeSubscription: TaskSubscriptionHandle, job: ActivatedJob, zeebeClient: CamundaClient) {
     if (activeSubscription.matches(job)) {
-      subscriptionRepository.activateSubscriptionForTask("${job.key}", activeSubscription)
+      val taskId = "${job.key}"
+      subscriptionRepository.activateSubscriptionForTask(taskId, activeSubscription)
       val variables = job.variablesAsMap.filterBySubscription(activeSubscription)
       try {
         logger.debug { "PROCESS-ENGINE-C8-041: Delivering user task ${job.key}." }
         activeSubscription.action.accept(job.toTaskInformation().withReason(TaskInformation.CREATE), variables)
         logger.debug { "PROCESS-ENGINE-C8-042: Successfully delivered user task ${job.key}." }
       } catch (e: Exception) {
-        logger.error { "PROCESS-ENGINE-C8-043: Failed to deliver user task ${job.key}: ${e.message}" }
-        zeebeClient
-          .newFailCommand(job.key)
-          .retries(job.retries)
-          .send()
-          .join() // could not deliver
-        subscriptionRepository.deactivateSubscriptionForTask(taskId = "${job.key}")
+        logger.error(e) { "PROCESS-ENGINE-C8-043: Failed to deliver user task ${job.key}: ${e.message}" }
+        try {
+          zeebeClient
+            .newFailCommand(job.key)
+            .retries(job.retries)
+            .send()
+            .join() // could not deliver
+        } finally {
+          deactivateAndTerminate(taskId)
+        }
       }
     } else {
       // put it back
@@ -86,7 +91,7 @@ class SubscribingRefreshingZeebeJobUserTaskDelivery(
     }
   }
 
-  override fun refresh() {
+  override fun refresh() = synchronized(refreshMonitor) {
     val subscriptions = subscriptionRepository.getDeliveredTaskIds(TaskType.USER)
     logger.trace { "PROCESS-ENGINE-C8-047: refreshing user tasks for subscriptions: $subscriptions" }
     if (subscriptions.isNotEmpty()) {
@@ -102,12 +107,9 @@ class SubscribingRefreshingZeebeJobUserTaskDelivery(
         } catch (e: ClientStatusException) {
           when (e.statusCode) {
             Status.Code.NOT_FOUND -> {
-              subscriptionRepository.getActiveSubscriptionForTask(taskId)?.let {
-                logger.trace { "PROCESS-ENGINE-C8-050: User task is gone, sending termination to the handler." }
-                it.termination.accept(TaskInformation(taskId, mapOf()).withReason(TaskInformation.DELETE))
-                subscriptionRepository.deactivateSubscriptionForTask(taskId)
-                logger.trace { "PROCESS-ENGINE-C8-051: Termination sent to handler and user task is removed." }
-              }
+              logger.trace { "PROCESS-ENGINE-C8-050: User task is gone, sending termination to the handler." }
+              deactivateAndTerminate(taskId)
+              logger.trace { "PROCESS-ENGINE-C8-051: Termination sent to handler and user task is removed." }
             }
 
             else -> logger.error(e) { "PROCESS-ENGINE-C8-052: Error extending job $taskId, ${e.message}." }
@@ -116,6 +118,16 @@ class SubscribingRefreshingZeebeJobUserTaskDelivery(
       }
     } else {
       logger.trace { "PROCESS-ENGINE-C8-053: not subscribing for user tasks, no active subscription found." }
+    }
+  }
+
+  private fun deactivateAndTerminate(taskId: String) {
+    subscriptionRepository.deactivateSubscriptionForTask(taskId)?.let {
+      try {
+        it.termination.accept(TaskInformation(taskId, mapOf()).withReason(TaskInformation.DELETE))
+      } catch (terminationError: Exception) {
+        logger.error(terminationError) { "PROCESS-ENGINE-C8-056: Failed to terminate user task $taskId during cleanup." }
+      }
     }
   }
 

--- a/engine-adapter/c8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingServiceTaskDelivery.kt
+++ b/engine-adapter/c8-core/src/main/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingServiceTaskDelivery.kt
@@ -49,17 +49,21 @@ class SubscribingServiceTaskDelivery(
 
   private fun consumeActivatedJob(activeSubscription: TaskSubscriptionHandle, job: ActivatedJob, camundaClient: CamundaClient) {
     if (activeSubscription.matches(job)) {
-      subscriptionRepository.activateSubscriptionForTask("${job.key}", activeSubscription)
+      val taskId = "${job.key}"
+      subscriptionRepository.activateSubscriptionForTask(taskId, activeSubscription)
       val variables = job.variablesAsMap.filterBySubscription(activeSubscription)
       try {
         logger.debug { "PROCESS-ENGINE-C8-051: Delivering service task ${job.key}." }
         activeSubscription.action.accept(job.toTaskInformation().withReason(TaskInformation.CREATE), variables)
         logger.debug { "PROCESS-ENGINE-C8-052: Successfully delivered service task ${job.key}." }
       } catch (e: Exception) {
-        logger.error { "PROCESS-ENGINE-C8-051: Failing to deliver service task ${job.key}: ${e.message}." }
-        camundaClient.newFailCommand(job.key).retries(job.retries.minus(1))
-          .retryBackoff(Duration.ofSeconds(retryTimeoutInSeconds)).send().join() // could not deliver
-        subscriptionRepository.deactivateSubscriptionForTask(taskId = "${job.key}")
+        logger.error(e) { "PROCESS-ENGINE-C8-051: Failing to deliver service task ${job.key}: ${e.message}." }
+        try {
+          camundaClient.newFailCommand(job.key).retries(job.retries.minus(1))
+            .retryBackoff(Duration.ofSeconds(retryTimeoutInSeconds)).send().join() // could not deliver
+        } finally {
+          deactivateAndTerminate(taskId)
+        }
         logger.error { "PROCESS-ENGINE-C8-052: Successfully failed to deliver service task ${job.key}: ${e.message}." }
       }
     } else {
@@ -71,6 +75,16 @@ class SubscribingServiceTaskDelivery(
       logger.trace { "PROCESS-ENGINE-C8-045: Successfully returned service task ${job.key} not matching subscriptions." }
     }
 
+  }
+
+  private fun deactivateAndTerminate(taskId: String) {
+    subscriptionRepository.deactivateSubscriptionForTask(taskId)?.let {
+      try {
+        it.termination.accept(TaskInformation(taskId, mapOf()).withReason(TaskInformation.DELETE))
+      } catch (terminationError: Exception) {
+        logger.error(terminationError) { "PROCESS-ENGINE-C8-054: Failed to terminate service task ${taskId} during cleanup." }
+      }
+    }
   }
 
   /*

--- a/engine-adapter/c8-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/PullUserTaskDeliveryTest.kt
+++ b/engine-adapter/c8-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/PullUserTaskDeliveryTest.kt
@@ -1,0 +1,106 @@
+package dev.bpmcrafters.processengineapi.adapter.c8.task.delivery
+
+import dev.bpmcrafters.processengineapi.impl.task.InMemSubscriptionRepository
+import dev.bpmcrafters.processengineapi.impl.task.TaskSubscriptionHandle
+import dev.bpmcrafters.processengineapi.task.TaskHandler
+import dev.bpmcrafters.processengineapi.task.TaskType
+import dev.bpmcrafters.processengineapi.task.support.UserTaskSupport
+import io.camunda.client.CamundaClient
+import io.camunda.client.api.CamundaFuture
+import io.camunda.client.api.search.enums.UserTaskState
+import io.camunda.client.api.search.request.UserTaskSearchRequest
+import io.camunda.client.api.search.request.UserTaskVariableSearchRequest
+import io.camunda.client.api.search.response.SearchResponse
+import io.camunda.client.api.search.response.UserTask
+import io.camunda.client.api.search.response.Variable
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.time.OffsetDateTime
+import java.util.function.Consumer
+
+class PullUserTaskDeliveryTest {
+
+  companion object {
+    private const val TASK_ID = "1234"
+    private const val ELEMENT_ID = "user-task"
+    private const val BPMN_PROCESS_ID = "simple-process"
+    private const val PROCESS_DEFINITION_KEY = 444L
+    private const val PROCESS_INSTANCE_KEY = 333L
+    private const val TENANT_ID = "tenant-1"
+  }
+
+  @Test
+  fun `should terminate locally cached user task when pull delivery fails`() {
+    val camundaClient = mock<CamundaClient>()
+    val subscriptionRepository = InMemSubscriptionRepository()
+    val userTaskSupport = UserTaskSupport()
+    userTaskSupport.addHandler(TaskHandler { _, _ -> error("boom") })
+
+    subscriptionRepository.createTaskSubscription(
+      TaskSubscriptionHandle(
+        taskType = TaskType.USER,
+        taskDescriptionKey = ELEMENT_ID,
+        restrictions = emptyMap(),
+        payloadDescription = null,
+        action = userTaskSupport::onTaskDelivery,
+        termination = userTaskSupport::onTaskRemoval
+      )
+    )
+    val task = userTask()
+
+    val searchRequest = mock<UserTaskSearchRequest>()
+    val searchFuture = mock<CamundaFuture<SearchResponse<UserTask>>>()
+    val searchResponse = mock<SearchResponse<UserTask>>()
+    whenever(camundaClient.newUserTaskSearchRequest()).thenReturn(searchRequest)
+    whenever(searchRequest.filter(any<Consumer<io.camunda.client.api.search.filter.UserTaskFilter>>())).thenReturn(searchRequest)
+    whenever(searchRequest.send()).thenReturn(searchFuture)
+    whenever(searchFuture.join()).thenReturn(searchResponse)
+    whenever(searchResponse.items()).thenReturn(listOf(task), emptyList())
+
+    val variableSearchRequest = mock<UserTaskVariableSearchRequest>()
+    val variableSearchFuture = mock<CamundaFuture<SearchResponse<Variable>>>()
+    val variableSearchResponse = mock<SearchResponse<Variable>>()
+    whenever(camundaClient.newUserTaskVariableSearchRequest(TASK_ID.toLong())).thenReturn(variableSearchRequest)
+    whenever(variableSearchRequest.withFullValues()).thenReturn(variableSearchRequest)
+    whenever(variableSearchRequest.send()).thenReturn(variableSearchFuture)
+    whenever(variableSearchFuture.join()).thenReturn(variableSearchResponse)
+    whenever(variableSearchResponse.items()).thenReturn(emptyList())
+
+    val delivery = PullUserTaskDelivery(
+      camundaClient = camundaClient,
+      subscriptionRepository = subscriptionRepository
+    )
+
+    delivery.refresh()
+
+    assertThat(userTaskSupport.exists(TASK_ID)).isFalse()
+    assertThat(subscriptionRepository.getActiveSubscriptionForTask(TASK_ID)).isNull()
+
+    delivery.refresh()
+
+    assertThat(userTaskSupport.getAllTasks()).isEmpty()
+  }
+
+  private fun userTask(): UserTask =
+    mock {
+      whenever(it.userTaskKey).thenReturn(TASK_ID.toLong())
+      whenever(it.name).thenReturn("Approve request")
+      whenever(it.state).thenReturn(UserTaskState.CREATED)
+      whenever(it.assignee).thenReturn("kermit")
+      whenever(it.elementId).thenReturn(ELEMENT_ID)
+      whenever(it.candidateGroups).thenReturn(emptyList())
+      whenever(it.candidateUsers).thenReturn(emptyList())
+      whenever(it.bpmnProcessId).thenReturn(BPMN_PROCESS_ID)
+      whenever(it.processName).thenReturn("Simple process")
+      whenever(it.processDefinitionKey).thenReturn(PROCESS_DEFINITION_KEY)
+      whenever(it.processInstanceKey).thenReturn(PROCESS_INSTANCE_KEY)
+      whenever(it.formKey).thenReturn(null)
+      whenever(it.creationDate).thenReturn(OffsetDateTime.parse("2026-07-03T10:15:30+02:00"))
+      whenever(it.followUpDate).thenReturn(null)
+      whenever(it.dueDate).thenReturn(null)
+      whenever(it.tenantId).thenReturn(TENANT_ID)
+    }
+}

--- a/engine-adapter/c8-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingRefreshingZeebeJobUserTaskDeliveryTest.kt
+++ b/engine-adapter/c8-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingRefreshingZeebeJobUserTaskDeliveryTest.kt
@@ -3,21 +3,41 @@ package dev.bpmcrafters.processengineapi.adapter.c8.task.delivery
 import dev.bpmcrafters.processengineapi.CommonRestrictions
 import dev.bpmcrafters.processengineapi.impl.task.InMemSubscriptionRepository
 import dev.bpmcrafters.processengineapi.impl.task.TaskSubscriptionHandle
+import dev.bpmcrafters.processengineapi.task.TaskHandler
 import dev.bpmcrafters.processengineapi.task.TaskType
+import dev.bpmcrafters.processengineapi.task.support.UserTaskSupport
 import io.camunda.client.CamundaClient
+import io.camunda.client.api.CamundaFuture
+import io.camunda.client.api.command.FailJobCommandStep1
+import io.camunda.client.api.response.FailJobResponse
 import io.camunda.client.api.response.ActivatedJob
+import io.camunda.client.api.worker.JobClient
+import io.camunda.client.api.worker.JobHandler
 import io.camunda.client.api.worker.JobWorker
 import io.camunda.client.api.worker.JobWorkerBuilderStep1
 import io.camunda.client.api.worker.JobWorkerBuilderStep1.JobWorkerBuilderStep2
 import io.camunda.client.api.worker.JobWorkerBuilderStep1.JobWorkerBuilderStep3
+import io.camunda.zeebe.protocol.Protocol
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class SubscribingRefreshingZeebeJobUserTaskDeliveryTest {
+
+  companion object {
+    private const val JOB_KEY = 9876L
+    private const val TASK_ID = "9876"
+    private const val ELEMENT_ID = "user-task-1"
+    private const val TENANT_ID = "tenant-1"
+    private const val PROCESS_INSTANCE_KEY = 333L
+    private const val PROCESS_DEFINITION_KEY = 444L
+    private const val BPMN_PROCESS_ID = "simple-process"
+    private const val RETRIES = 3
+  }
 
   // We need an instance of SubscribingRefreshingUserTaskDelivery because matches is an extension function
   // on TaskSubscriptionHandle declared inside SubscribingRefreshingUserTaskDelivery class.
@@ -201,4 +221,72 @@ class SubscribingRefreshingZeebeJobUserTaskDeliveryTest {
     delivery.unsubscribe(subscription)
     verify(jobWorker).close()
   }
+
+  @Test
+  fun `should terminate locally cached user task when subscribed delivery fails`() {
+    val subscriptionRepository = InMemSubscriptionRepository()
+    val userTaskSupport = UserTaskSupport()
+    userTaskSupport.addHandler(TaskHandler { _, _ -> error("boom") })
+
+    val subscription = TaskSubscriptionHandle(
+      taskType = TaskType.USER,
+      taskDescriptionKey = ELEMENT_ID,
+      restrictions = emptyMap(),
+      payloadDescription = null,
+      action = userTaskSupport::onTaskDelivery,
+      termination = userTaskSupport::onTaskRemoval
+    )
+    subscriptionRepository.createTaskSubscription(subscription)
+
+    val camundaClient = mock<CamundaClient>()
+    val workerBuilder = mock<JobWorkerBuilderStep1>()
+    val workerBuilder2 = mock<JobWorkerBuilderStep2>()
+    val workerBuilder3 = mock<JobWorkerBuilderStep3>()
+    val jobWorker = mock<JobWorker>()
+    val handler = argumentCaptor<JobHandler>()
+
+    whenever(camundaClient.newWorker()).thenReturn(workerBuilder)
+    whenever(workerBuilder.jobType(any())).thenReturn(workerBuilder2)
+    whenever(workerBuilder2.handler(handler.capture())).thenReturn(workerBuilder3)
+    whenever(workerBuilder3.maxJobsActive(any())).thenReturn(workerBuilder3)
+    whenever(workerBuilder3.name(any())).thenReturn(workerBuilder3)
+    whenever(workerBuilder3.timeout(any<Long>())).thenReturn(workerBuilder3)
+    whenever(workerBuilder3.streamEnabled(any())).thenReturn(workerBuilder3)
+    whenever(workerBuilder3.open()).thenReturn(jobWorker)
+
+    val failJobStep1 = mock<FailJobCommandStep1>()
+    val failJobStep2 = mock<FailJobCommandStep1.FailJobCommandStep2>()
+    val failJobFuture = mock<CamundaFuture<FailJobResponse>>()
+    whenever(camundaClient.newFailCommand(JOB_KEY)).thenReturn(failJobStep1)
+    whenever(failJobStep1.retries(RETRIES)).thenReturn(failJobStep2)
+    whenever(failJobStep2.send()).thenReturn(failJobFuture)
+
+    val delivery = SubscribingRefreshingZeebeJobUserTaskDelivery(
+      camundaClient = camundaClient,
+      subscriptionRepository = subscriptionRepository,
+      workerId = "test-worker",
+      userTaskLockTimeoutMs = 60000L
+    )
+
+    delivery.subscribe()
+
+    handler.firstValue.handle(mock<JobClient>(), activatedJob())
+
+    assertThat(userTaskSupport.exists(TASK_ID)).isFalse()
+    assertThat(subscriptionRepository.getActiveSubscriptionForTask(TASK_ID)).isNull()
+  }
+
+  private fun activatedJob(): ActivatedJob =
+    mock {
+      whenever(it.key).thenReturn(JOB_KEY)
+      whenever(it.retries).thenReturn(RETRIES)
+      whenever(it.type).thenReturn(Protocol.USER_TASK_JOB_TYPE)
+      whenever(it.elementId).thenReturn(ELEMENT_ID)
+      whenever(it.tenantId).thenReturn(TENANT_ID)
+      whenever(it.bpmnProcessId).thenReturn(BPMN_PROCESS_ID)
+      whenever(it.processDefinitionKey).thenReturn(PROCESS_DEFINITION_KEY)
+      whenever(it.processInstanceKey).thenReturn(PROCESS_INSTANCE_KEY)
+      whenever(it.variablesAsMap).thenReturn(emptyMap())
+      whenever(it.customHeaders).thenReturn(emptyMap())
+    }
 }

--- a/engine-adapter/c8-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingServiceTaskDeliveryTest.kt
+++ b/engine-adapter/c8-core/src/test/kotlin/dev/bpmcrafters/processengineapi/adapter/c8/task/delivery/SubscribingServiceTaskDeliveryTest.kt
@@ -1,15 +1,40 @@
 package dev.bpmcrafters.processengineapi.adapter.c8.task.delivery
 
 import dev.bpmcrafters.processengineapi.CommonRestrictions
+import dev.bpmcrafters.processengineapi.task.TaskHandler
+import dev.bpmcrafters.processengineapi.task.TaskInformation
+import dev.bpmcrafters.processengineapi.task.TaskTerminationHandler
 import dev.bpmcrafters.processengineapi.impl.task.TaskSubscriptionHandle
 import dev.bpmcrafters.processengineapi.task.TaskType
+import io.camunda.client.CamundaClient
+import io.camunda.client.api.CamundaFuture
+import io.camunda.client.api.command.FailJobCommandStep1
 import io.camunda.client.api.response.ActivatedJob
+import io.camunda.client.api.response.FailJobResponse
+import io.camunda.client.api.worker.JobClient
+import io.camunda.client.api.worker.JobHandler
+import io.camunda.client.api.worker.JobWorker
+import io.camunda.client.api.worker.JobWorkerBuilderStep1
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.time.Duration
 
 class SubscribingServiceTaskDeliveryTest {
+
+  companion object {
+    private const val JOB_KEY = 1234L
+    private const val TASK_ID = "1234"
+    private const val TOPIC = "test-topic"
+    private const val ELEMENT_ID = "activity-1"
+    private const val TENANT_ID = "tenant-1"
+    private const val PROCESS_INSTANCE_KEY = 333L
+    private const val PROCESS_DEFINITION_KEY = 444L
+    private const val RETRIES = 3
+  }
 
   // We need an instance of SubscribingServiceTaskDelivery because matches is an extension function
   // on TaskSubscriptionHandle declared inside SubscribingServiceTaskDelivery class.
@@ -154,4 +179,79 @@ class SubscribingServiceTaskDeliveryTest {
       assertThat(subscription.matches(job)).isTrue()
     }
   }
+
+  @Test
+  fun `should terminate locally cached service task when subscribed delivery fails`() {
+    val cachedTasks = linkedMapOf<String, TaskInformation>()
+    var termination: TaskInformation? = null
+    val subscription = TaskSubscriptionHandle(
+      taskType = TaskType.EXTERNAL,
+      taskDescriptionKey = TOPIC,
+      restrictions = emptyMap(),
+      payloadDescription = null,
+      action = TaskHandler { taskInformation, _ ->
+        cachedTasks[taskInformation.taskId] = taskInformation
+        error("boom")
+      },
+      termination = TaskTerminationHandler { taskInformation ->
+        termination = taskInformation
+        cachedTasks.remove(taskInformation.taskId)
+      }
+    )
+
+    val subscriptionRepository = dev.bpmcrafters.processengineapi.impl.task.InMemSubscriptionRepository().apply {
+      createTaskSubscription(subscription)
+    }
+    val camundaClient = mock<CamundaClient>()
+    val workerBuilder = mock<JobWorkerBuilderStep1>()
+    val workerBuilder2 = mock<JobWorkerBuilderStep1.JobWorkerBuilderStep2>()
+    val workerBuilder3 = mock<JobWorkerBuilderStep1.JobWorkerBuilderStep3>()
+    val jobWorker = mock<JobWorker>()
+    val handler = argumentCaptor<JobHandler>()
+
+    whenever(camundaClient.newWorker()).thenReturn(workerBuilder)
+    whenever(workerBuilder.jobType(TOPIC)).thenReturn(workerBuilder2)
+    whenever(workerBuilder2.handler(handler.capture())).thenReturn(workerBuilder3)
+    whenever(workerBuilder3.name(any())).thenReturn(workerBuilder3)
+    whenever(workerBuilder3.timeout(any<Long>())).thenReturn(workerBuilder3)
+    whenever(workerBuilder3.open()).thenReturn(jobWorker)
+
+    val failJobStep1 = mock<FailJobCommandStep1>()
+    val failJobStep2 = mock<FailJobCommandStep1.FailJobCommandStep2>()
+    val failJobFuture = mock<CamundaFuture<FailJobResponse>>()
+    whenever(camundaClient.newFailCommand(JOB_KEY)).thenReturn(failJobStep1)
+    whenever(failJobStep1.retries(RETRIES - 1)).thenReturn(failJobStep2)
+    whenever(failJobStep2.retryBackoff(Duration.ofSeconds(10))).thenReturn(failJobStep2)
+    whenever(failJobStep2.send()).thenReturn(failJobFuture)
+
+    val delivery = SubscribingServiceTaskDelivery(
+      camundaClient = camundaClient,
+      subscriptionRepository = subscriptionRepository,
+      workerId = "test-worker",
+      retryTimeoutInSeconds = 10,
+      lockDurationInSeconds = 60
+    )
+
+    delivery.subscribe()
+
+    handler.firstValue.handle(mock<JobClient>(), activatedJob())
+
+    assertThat(cachedTasks).isEmpty()
+    assertThat(termination?.taskId).isEqualTo(TASK_ID)
+    assertThat(termination?.meta).containsEntry(TaskInformation.REASON, TaskInformation.DELETE)
+    assertThat(subscriptionRepository.getActiveSubscriptionForTask(TASK_ID)).isNull()
+  }
+
+  private fun activatedJob(): ActivatedJob =
+    mock {
+      whenever(it.key).thenReturn(JOB_KEY)
+      whenever(it.retries).thenReturn(RETRIES)
+      whenever(it.type).thenReturn(TOPIC)
+      whenever(it.elementId).thenReturn(ELEMENT_ID)
+      whenever(it.tenantId).thenReturn(TENANT_ID)
+      whenever(it.processInstanceKey).thenReturn(PROCESS_INSTANCE_KEY)
+      whenever(it.processDefinitionKey).thenReturn(PROCESS_DEFINITION_KEY)
+      whenever(it.variablesAsMap).thenReturn(emptyMap())
+      whenever(it.customHeaders).thenReturn(emptyMap())
+    }
 }


### PR DESCRIPTION
Task delivery strategies were badly handling the case of error during delivery and didn't call the termination handlers in cases of errors. That leaded to out-of-sync between e.g. `UserTaskSupport` and engine. 

This PR fixes this behaviour.